### PR TITLE
[Settings] 코어 프로젝트 세팅

### DIFF
--- a/algofi-core/build.gradle
+++ b/algofi-core/build.gradle
@@ -24,10 +24,14 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/algofi-core/build.gradle
+++ b/algofi-core/build.gradle
@@ -23,6 +23,9 @@ repositories {
 	mavenCentral()
 }
 
+def profile = project.hasProperty('profile') ? project.profile : 'dev'
+
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -33,6 +36,10 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	if(profile == 'dev') {
+		runtimeOnly 'com.h2database:h2'
+	}
 }
 
 tasks.named('test') {

--- a/algofi-core/src/main/resources/application-dev.properties
+++ b/algofi-core/src/main/resources/application-dev.properties
@@ -1,0 +1,9 @@
+spring.h2.console.enabled=true
+spring.h2.console.path=/h2-console
+spring.datasource.url=jdbc:h2:~/local
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.H2Dialect
+spring.jpa.hibernate.ddl-auto=update

--- a/algofi-core/src/main/resources/application.properties
+++ b/algofi-core/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=algofi-core
+spring.profiles.default=dev


### PR DESCRIPTION
## 📌 Summary
코어 프로젝트에 라이브러리 추가, 개발, 운영용 프로필 설정

## 📝 Describe your changes
아무런 프로필 값도 주지 않으면 개발 프로필로 동작함
프로필 설정에 따라 다른 application.properties 설정을 불러옴
또, gradle 빌드 시 h2 db의 포함 여부가 결정됨

## 🔗 Issue number and link

## Screenshot(optional)

## To Reviewers
