### PR TITLE
fix: db utf8 encoding

### DIFF
--- a/algofi-mysql/Dockerfile
+++ b/algofi-mysql/Dockerfile
@@ -6,8 +6,8 @@ FROM mysql:oraclelinux9
 # 이 디렉토리에 파일을 넣으면 MySQL이 자동으로 이 설정 파일을 읽게 됩니다.
 #COPY ./config/mysql.cnf /etc/my.cnf
 #RUN chmod 644 /etc/my.cnf
-COPY ./config/mysql.cnf /etc/my.cnf.d/my.cnf
-RUN chmod 644 /etc/my.cnf.d/my.cnf
+COPY ./config/mysql.cnf /etc/my.cnf
+RUN chmod 644 /etc/my.cnf
 
 # init 파일을 /docker-entrypoint-initdb.d/로 복사
 # 이 디렉토리에 있는 SQL 스크립트는 컨테이너가 처음 실행 시 자동 실행됨

--- a/algofi-mysql/config/mysql.cnf
+++ b/algofi-mysql/config/mysql.cnf
@@ -1,5 +1,4 @@
 [mysqld]
-skip-host-cache
 skip-name-resolve
 datadir=/var/lib/mysql
 socket=/var/run/mysqld/mysqld.sock
@@ -7,13 +6,17 @@ secure-file-priv=/var/lib/mysql-files
 user=mysql
 pid-file=/var/run/mysqld/mysqld.pid
 character-set-server=utf8mb4
-collation-server=utf8mb4_general_ci
+collation-server=utf8mb4_0900_ai_ci
+init_connect='SET NAMES utf8mb4'
 
 [client]
 socket=/var/run/mysqld/mysqld.sock
 default-character-set=utf8mb4
 
 [mysql]
+default-character-set=utf8mb4
+
+[mysqldump]
 default-character-set=utf8mb4
 
 !includedir /etc/mysql/conf.d/

--- a/algofi-mysql/init/create_table.sql
+++ b/algofi-mysql/init/create_table.sql
@@ -1,3 +1,4 @@
+ALTER DATABASE mydb DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
 /* member table 생성 */
 CREATE TABLE member (
                         member_id INT(11) AUTO_INCREMENT PRIMARY KEY,
@@ -12,7 +13,7 @@ CREATE TABLE member (
                         login_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                         created_date TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                         updated_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
-)CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+) character set utf8mb4 collate utf8mb4_general_ci;
 
 /* filestorage table 생성 */
 CREATE TABLE filestorage (
@@ -22,7 +23,7 @@ CREATE TABLE filestorage (
                              created_time TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                              updated_time TIMESTAMP,
                              FOREIGN KEY(member_id) REFERENCES member(member_id)
-)CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+) character set utf8mb4 collate utf8mb4_general_ci;
 
 /* file table 생성 */
 CREATE TABLE file (
@@ -36,7 +37,7 @@ CREATE TABLE file (
                       parent_id INT NULL,
                       FOREIGN KEY(file_storage_id) REFERENCES filestorage(file_storage_id),
                       FOREIGN KEY(parent_id) REFERENCES file(file_id) ON DELETE CASCADE
-)CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+) character set utf8mb4 collate utf8mb4_general_ci;
 
 /* algorithmproblem table 생성 */
 CREATE TABLE algorithmproblem (
@@ -45,13 +46,13 @@ CREATE TABLE algorithmproblem (
                                   level VARCHAR(10) NOT NULL,
                                   content TEXT,
                                   recommend_time INT
-)CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+) character set utf8mb4 collate utf8mb4_general_ci;
 
 /* chatroom table 생성 */
 CREATE TABLE chatroom (
                           chatroom_id VARCHAR(36) PRIMARY KEY,
                           chatroom_name VARCHAR(100)
-)CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+) character set utf8mb4 collate utf8mb4_general_ci;
 
 /* message table 생성 */
 CREATE TABLE message (
@@ -63,15 +64,15 @@ CREATE TABLE message (
                          chatroom_id VARCHAR(36) NOT NULL,
                          FOREIGN KEY(sender_id) REFERENCES member(member_id),
                          FOREIGN KEY(chatroom_id) REFERENCES chatroom(chatroom_id)
-)CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+) character set utf8mb4 collate utf8mb4_general_ci;
 
 /* member_chatroom table 생성 */
 CREATE TABLE member_chatroom (
                                  chatroom_id VARCHAR(36) NOT NULL,
                                  member_id INT NULL,
                                  FOREIGN KEY(chatroom_id) REFERENCES chatroom(chatroom_id),
-                                 FOREIGN KEY(member_id) REFERENCES  member(member_id)
-);
+                                 FOREIGN KEY(member_id) REFERENCES member(member_id)
+) character set utf8mb4 collate utf8mb4_general_ci;
 
 /* gameresult table 생성 */
 CREATE TABLE gameresult (
@@ -84,7 +85,7 @@ CREATE TABLE gameresult (
                             chatroom_id VARCHAR(36) NOT NULL,
                             FOREIGN KEY (algorithmproblem_id) REFERENCES algorithmproblem(algorithmproblem_id),
                             FOREIGN KEY (chatroom_id) REFERENCES chatroom(chatroom_id)
-)CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+) character set utf8mb4 collate utf8mb4_general_ci;
 
 /* member_gameresult table 생성 */
 CREATE TABLE member_gameresult (
@@ -92,7 +93,7 @@ CREATE TABLE member_gameresult (
                                    member_id INT NOT NULL,
                                    FOREIGN KEY(game_result_id) REFERENCES gameresult(game_result_id),
                                    FOREIGN KEY(member_id) REFERENCES member(member_id)
-);
+) character set utf8mb4 collate utf8mb4_general_ci;
 
 /* testcase table 생성 */
 CREATE TABLE testcase (
@@ -101,4 +102,4 @@ CREATE TABLE testcase (
                           test_output VARCHAR(500),
                           algorithmproblem_id INT NOT NULL,
                           FOREIGN KEY(algorithmproblem_id) REFERENCES algorithmproblem(algorithmproblem_id)
-)CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci;
+) character set utf8mb4 collate utf8mb4_general_ci;


### PR DESCRIPTION
## 📌 Summary
- db utf8 encoding 해결
- /etc/my.cnf.d/my.cnf -> /etc/my.cnf 로 변경

## 📝 Describe your changes

## 🔗 Issue number and link

## Screenshot(optional)

## To Reviewers
